### PR TITLE
Fixing: TabError: inconsistent use of tabs and spaces in indentation on line 119 in Meshblu.py

### DIFF
--- a/knotpy/Meshblu.py
+++ b/knotpy/Meshblu.py
@@ -116,7 +116,7 @@ class Meshblu(object):
 		devices = ProtoSocketio().getDevices(credentials,
 							{'gateways': ['*']})
 		uuid = getDeviceUuid(devices, device_id)
-                schema = [dev.get('schema') for dev in devices if dev.get('uuid') == uuid][0]
+		schema = [dev.get('schema') for dev in devices if dev.get('uuid') == uuid][0]
 		try:
 			return [sensor.get('sensor_id') for sensor in schema]
 		except KeyError as err:


### PR DESCRIPTION
When try to use KnotConnection() I got:

`Traceback (most recent call last):
  File "knot.py", line 1, in <module>
    from knotpy import KnotConnection
  File "/home/CIN/wssj2/envname/lib/python3.6/site-packages/knotpy/__init__.py", line 26, in <module>
    from .knot import KnotConnection
  File "/home/CIN/wssj2/envname/lib/python3.6/site-packages/knotpy/knot.py", line 1, in <module>
    from .cloud_factory import CloudFactory
  File "/home/CIN/wssj2/envname/lib/python3.6/site-packages/knotpy/cloud_factory.py", line 2, in <module>
    from .Meshblu import Meshblu
  File "/home/CIN/wssj2/envname/lib/python3.6/site-packages/knotpy/Meshblu.py", line 119
    schema = [dev.get('schema') for dev in devices if dev.get('uuid') == uuid][0]`

So I find wrong indentation on Meshblu.py